### PR TITLE
Fix bug at advice at delete other windows

### DIFF
--- a/e2wm.el
+++ b/e2wm.el
@@ -1070,7 +1070,7 @@ management. For window-layout.el.")
     ad-do-it))
 
 (defadvice delete-other-windows (around e2wm:ad-override)
-  (when e2wm:delete-other-windows-permission
+  (when (or e2wm:delete-other-windows-permission (not (e2wm:managed-p)))
     ad-do-it))
 
 ;; コンパイルエラーのような他のウインドウへの表示をする拡張への対応


### PR DESCRIPTION
e2wm:pst-minor-modeが有効で，e2wmでフレームが管理されていない場合にdelete-other-windowが動作しなくなっていました．
このadviceが追加された経緯は以下のツイートだと思うのですが，この変更で問題ないのか確認してください．
http://twitter.com/#!/yosisa/status/33413696516530176
