### PR TITLE
Change argument of switch-to-buffer to work with emacs24.

### DIFF
--- a/e2wm.el
+++ b/e2wm.el
@@ -994,7 +994,7 @@ from the given string."
 
 (defadvice switch-to-buffer (around
                              e2wm:ad-override
-                             (buf &optional norecord))
+                             (buf &optional norecord force-same-window))
   (e2wm:message "#SWITCH-TO-BUFFER %s" buf)
   (let (overrided)
     (when (and buf 


### PR DESCRIPTION
emacs24で動くように変更しました。
24から、switch-to-bufferの引数にFORCE-SAME-WINDOWが追加されたようです。
この変更後、emacs23, 24で動作することを確認しました。
