### PR TITLE
fixed e2wm-vcs.el: raise no error from require

### DIFF
--- a/e2wm-vcs.el
+++ b/e2wm-vcs.el
@@ -30,8 +30,8 @@
 ;;; Code:
 
 (require 'e2wm)
-(require 'magit)
-(require 'dsvn)
+(require 'magit nil t)
+(require 'dsvn nil t)
 
 
 ;;; Utilities


### PR DESCRIPTION
magit は使っているけど dvcs は使ってない場合(またはその逆)でも e2wm-vcs.el が使えるようにしてみました。よろしければpullして下さい。
