### PR TITLE
Feature idea for vcs: select plugin window when select/popup to their buffer

### DIFF
--- a/e2wm-vcs.el
+++ b/e2wm-vcs.el
@@ -323,7 +323,6 @@
           (not-minibufp (= 0 (minibuffer-depth))))
       (e2wm:with-advice
        (cond
-        ((e2wm:vcs-select-if-plugin buf))
         ((equal buf-name monky-commit-buffer-name)
          ;; displaying commit objects in the main window
          (e2wm:pst-buffer-set 'main buf t nil))


### PR DESCRIPTION
popup/selectが呼ばれたときに、バッファがplugin windowで開かれている場合はそのwindowに移動する関数 (`e2wm:vcs-select-if-plugin`) を追加しました。これで、Magit/Monkyを使っている場合はそのモジュールの持つコマンドで目的のwindowにいけるようになります。e2wm-vcs.elに追加しましたが、 色んなバッファを作るモジュールをe2wmで使うための汎用的な関数として使えると思うので、e2wm.elに入れたほうが良いかもしれません。

また、この挙動を軸にperspectiveを変更してみました。細かいパラメタは変更したほうが良いかもしれませんが、デフォルトの挙動としてはこちらが良いのではと思います。お時間ある時に試してみて下さい。
