### PR TITLE
split command argument for start-process.

### DIFF
--- a/e2wm.el
+++ b/e2wm.el
@@ -1873,7 +1873,7 @@ string object to insert the imenu buffer."
         (buffer-disable-undo buf)))
     (let (proc)
       (condition-case err
-          (setq proc (start-process "WM:top" tmpbuf "top" "-b -n 1"))
+          (setq proc (start-process "WM:top" tmpbuf "top" "-b" "-n" "1"))
         (nil 
          (with-current-buffer buf
            (erase-buffer)


### PR DESCRIPTION
top プラグインが引数を正しく top コマンドに渡せていないようです。個別にクォートすれば正しく動作しました。
emacs-snapshot (emacs24) と emacs23、ともに debian sid 上での挙動です。
