### PR TITLE
fixed advices for switch/pop-to-buffer: return buffer

### DIFF
--- a/e2wm.el
+++ b/e2wm.el
@@ -1007,7 +1007,7 @@ from the given string."
     (if overrided
         (progn
           (set-buffer buf)
-          (setq ad-return-value buf))
+          (setq ad-return-value (get-buffer-create buf)))
       ad-do-it))) ; それ以外はもとの関数へ（画面更新はしないので必要な場合は自分でする）
 
 (defadvice pop-to-buffer (around 
@@ -1025,7 +1025,7 @@ from the given string."
     (if overrided
         (progn 
           (set-buffer buf)
-          (setq ad-return-value buf))
+          (setq ad-return-value (get-buffer-create buf)))
       ad-do-it))) ; それ以外はもとの関数へ（画面更新はしないので必要な場合は自分でする）
 
 (defun e2wm:override-special-display-function (buf &optional args)


### PR DESCRIPTION
The first argument of switch-to-buffer and pop-to-buffer can be a string, so you can't return it as-is.  You must convert it to a buffer explicitly.

`(invalid-function "*Local Variables*")` なるエラーが出て困っていました。どうやら、 files.el の `hack-local-variables-confirm` で `(let* (... (buf (pop-to-buffer "*Local Variables*"))) ...)` を呼んでいるのが原因だったようです。
