### PR TITLE
no error from e2wm:pst-get-wm when e2wm is not on

### DIFF
--- a/e2wm.el
+++ b/e2wm.el
@@ -731,7 +731,8 @@ raise the error signal with ERROR-ON-NIL."
 
 (defun e2wm:pst-get-wm ()
   "Return the window layout object of the current perspective."
-  (e2wm:$pst-wm (e2wm:pst-get-instance)))
+  (e2wm:aif (e2wm:pst-get-instance)
+      (e2wm:$pst-wm it)))
 
 (defun e2wm:pst-update-windows (&optional rebuild-windows)
   "Update all buffers of the windows and plug-ins.  If


### PR DESCRIPTION
fixes (part of) #12

---
#12 の 3番目の提案に関する fix です． e2wm 管理下に無い場合に e2wm:pst-get-wm を呼ぶとエラーは出さずに nil を返すようにしました．
