### PR TITLE
Use delete-frame-functions hook to switch on/off

### DIFF
--- a/e2wm.el
+++ b/e2wm.el
@@ -1089,10 +1089,11 @@ defined by the perspective."
 
 (defun e2wm:delete-frame-functions (frame)
   (e2wm:message "## DELETE FRAME HOOK [%s] " frame)
-  (let* ((next-frame (next-frame frame)))
-    (e2wm:message "## NEXT FRAME [%s] -> (%s)" frame next-frame)
-    (e2wm:pst-minor-mode-switch-frame next-frame)
-    (select-frame next-frame)))
+  (let* ((next-frame (car (filtered-frame-list #'e2wm:managed-p))))
+    (when next-frame
+      (e2wm:message "## NEXT FRAME [%s] -> (%s)" frame next-frame)
+      (e2wm:pst-minor-mode-switch-frame next-frame)
+      (select-frame next-frame))))
 
 (defadvice other-frame (after e2wm:ad-frame-override)
   (e2wm:message "## OTHER FRAME [%s] " (selected-frame))


### PR DESCRIPTION
Note that this hook cannot be added/removed in
e2wm:pst-minor-mode-disable/enable-frame like other
hooks as it is needed to be active in the deleted frame.

Fixes #34
