### PR TITLE
Fix a bug in kill-buffer-hook: can't kill the last

### DIFF
--- a/e2wm.el
+++ b/e2wm.el
@@ -1218,6 +1218,7 @@ Called via `kill-buffer-hook'."
              (buffers (e2wm:history-get-nearest killedbuf (length wins))))
         (loop for wname in wins
               for buf in buffers
+              when buf
               do (wlf:set-buffer wm wname buf))))
     ;; remove it from the history list
     (e2wm:history-delete (current-buffer))


### PR DESCRIPTION
When there is only one buffer remains in the history list, this buffer
cannot be killed and the message like the following will be shown:

```
wlf:set-buffer: Buffer is null! at wlf:set-buffer. (left)
```

This change fix this problem.

履歴に残った最後のバッファが消せないバグの修正です。 #32 でこのバグを混入させてしまったみたいです。
