### PR TITLE
e2wm:$pst-class に display method を追加

### DIFF
--- a/e2wm.el
+++ b/e2wm.el
@@ -3005,16 +3005,15 @@ Otherwise show and select it."
 Do not select the buffer."
   (e2wm:message "#DP TWO display : %s" buf)
   (cond
-   ((e2wm:document-buffer-p buf)
-    (e2wm:pst-buffer-set 'right buf)
-    t)
-   ((e2wm:history-recordable-p buf)
+   ((or (e2wm:history-recordable-p buf) ; we don't need to distinguish
+        (e2wm:document-buffer-p buf))   ; these two as we don't select
     (let ((wm (e2wm:pst-get-wm))
           (curwin (selected-window)))
       ;; show in the other window, but don't select.
       (if (eql curwin (wlf:get-window wm 'left))
           (e2wm:pst-buffer-set 'right buf)
         (e2wm:pst-buffer-set 'left buf)))
+    (e2wm:pst-update-windows)           ; update plugins, etc.
     t)
    (t
     (e2wm:pst-buffer-set 'sub buf t)


### PR DESCRIPTION
pop-to-buffer と (例えば) display-buffer を別々に制御するために新しく display メソッドを追加してみました。 以前の実装だと display-buffer が呼ばれたときには popup メソッドが呼ばれていましたが、これだと window を選択せずに表示するという display-buffer のもともとの挙動に相反する結果になってしまいます。

base パースペクティブクラスで display メソッドから popup メソッドを呼んでいるので、この変更で build-in のパースペクティブに支障がでることはないと思います。

two パースペクティブクラスで display メソッドを使ってみました。 例えば `(display-buffer "e2wm.el")` や `(pop-to-buffer "e2wm.el")` を評価することで挙動の違いを試すことが出来ます。前者だとフォーカスは移らず、後者だとフォーカスが移るはずです。
