### PR TITLE
e2wm:$pst-class に after-bury method を追加

### DIFF
--- a/e2wm.el
+++ b/e2wm.el
@@ -2759,8 +2759,15 @@ string object to insert the imenu buffer."
     (when win-name
       (e2wm:with-advice
        (e2wm:pst-buffer-set win-name (window-buffer window))))
-    ;; remove the buffer from the history
-    (when (get-buffer buried-buffer)
+    ;; remove the buffer from the history if it is the last buffer in
+    ;; the current frame
+    (when (loop for other-win in (window-list)
+                for other-buf = (window-buffer other-win)
+                when (and (eq other-buf buried-buffer)
+                          (not (eq other-win window)))
+                return nil
+                finally
+                return t)
       (e2wm:message "#REMOVED BUFFER %s" buried-buffer)
       (e2wm:history-delete buried-buffer))
     ;; execute plugins (e.g. to update history)


### PR DESCRIPTION
#37 で話題になった bury method を追加してみました。 この実装では bury を override するわけではないので after-bury という名前にしています。 デフォルトの動作を override する必要が出た時に bury method を追加すれば良いと思います。 method にしただけで大きな変更はありませんが、 two と code の sub を自動で閉じるようにしてみました。

ちなみに、こちらで不具合の確認がしやすいように #39 のブランチから生やしてあります。 master からにしたほうがよければそうします。
