### PR TITLE
Check e2wm:debug at run time, not compile time

### DIFF
--- a/e2wm.el
+++ b/e2wm.el
@@ -237,8 +237,8 @@ equals to NAME in the given sequence SEQ."
 
 (defmacro e2wm:message (&rest args) ; debug
   "Output a message into the debug buffer: *e2wm:debug*."
-  (when e2wm:debug
-    `(progn 
+  `(when e2wm:debug
+     (progn
        (with-current-buffer (get-buffer-create "*e2wm:debug*")
          (save-excursion
            (goto-char (point-max))


### PR DESCRIPTION
再コンパイルなしで `e2wm:message` を動くようにしてみました。

トリビアルな変更なのですが、この変更のあとで #41 でひとつバグ (22abd3d1dd8a2cd10c8939f19bf7198d7f08fdcb) を見つけたので PR を送っておきます。
