### PR TITLE
Suppress the default behavior when switching to right

### DIFF
--- a/e2wm.el
+++ b/e2wm.el
@@ -2960,7 +2960,7 @@ string object to insert the imenu buffer."
       ;; right画面の場合
       (e2wm:pst-buffer-set 'right buf)
       (e2wm:dp-two-update-history-list)
-      nil)
+      t)
      (t nil))))
 
 (defun e2wm:dp-two-popup (buf)


### PR DESCRIPTION
e2wm:dp-two-switch で、right画面の場合、 `(e2wm:pst-buffer-set 'right buf)` を呼んでいるのに nil を返しています。これではデフォルトの switch-to-buffer が呼ばれてしまいます。普通に使っている分にはどちらにせよそのwindowに居るので何度 switch-to-buffer を呼ばれようが問題ないのですが、 dp-two を継承して使っていると e2wm:dp-two-switch で乗っ取りが起こったのかどうか分からず不便です。 狙って nil を返しているのでなければ t を返すべきだと思いますが、どうでしょうか。
