### PR TITLE
Use e2wm:pst-change-keymap instead of per frame backup

### DIFF
--- a/e2wm.el
+++ b/e2wm.el
@@ -1083,22 +1083,12 @@ defined by the perspective."
 
 (defvar e2wm:pst-minor-mode-keymap-blank (make-sparse-keymap) "[internal]")
 
-(defun e2wm:pst-minor-mode-backup-frame-keymap (&optional frame)
-  (e2wm:message "## PST BACKUP KEYMAP ON %s (KEYMAP BACKUP %s)"
-                frame
-                (not (null (e2wm:frame-param-get 'e2wm:keymap-backup frame))))
-  (e2wm:aif (assq 'e2wm:pst-minor-mode minor-mode-map-alist)
-      (progn
-        (e2wm:frame-param-set 'e2wm:keymap-backup (cdr it) frame)
-        (setf (cdr it) e2wm:pst-minor-mode-keymap-blank))))
-
 (defun e2wm:pst-minor-mode-disable-frame (&optional frame)
-  (e2wm:message "## PST MM DISABLED ON %s (KEYMAP BACKUP %s)"
-                frame
-                (not (null (e2wm:frame-param-get 'e2wm:keymap-backup frame))))
+  (e2wm:message "## PST MM DISABLED ON %s" frame)
   ;;グローバルマイナーモードは有効のままで、アドバイス、キーマップのみ無効にする
   ;;特定のフレームで有効というイメージ
-  (e2wm:pst-minor-mode-backup-frame-keymap frame)
+  (e2wm:aif (assq 'e2wm:pst-minor-mode minor-mode-map-alist)
+      (setf (cdr it) e2wm:pst-minor-mode-keymap-blank))
 
   (remove-hook 'kill-buffer-hook 'e2wm:kill-buffer-hook)
   (remove-hook 'window-configuration-change-hook 
@@ -1110,19 +1100,10 @@ defined by the perspective."
   (ad-deactivate-regexp "^e2wm:ad-override$")
   )
 
-(defun e2wm:pst-minor-mode-restore-frame-keymap (&optional frame)
-  (e2wm:message "## PST RESTORE KEYMAP ON %s (KEYMAP BACKUP %s)"
-                frame
-                (not (null (e2wm:frame-param-get 'e2wm:keymap-backup frame))))
-  (e2wm:aif (assq 'e2wm:pst-minor-mode minor-mode-map-alist)
-      (setf (cdr it) (e2wm:frame-param-get 'e2wm:keymap-backup frame)))
-  (e2wm:frame-param-set 'e2wm:keymap-backup nil frame))
-
 (defun e2wm:pst-minor-mode-enable-frame (&optional frame)
-  (e2wm:message "## PST MM ENABLED ON %s (KEYMAP BACKUP %s)"
-                frame
-                (not (null (e2wm:frame-param-get 'e2wm:keymap-backup frame))))
-  (e2wm:pst-minor-mode-restore-frame-keymap frame)
+  (e2wm:message "## PST MM ENABLED ON %s" frame)
+  (e2wm:aif (e2wm:pst-get-instance frame)
+      (e2wm:pst-change-keymap (e2wm:$pst-keymap it)))
 
   (ad-activate-regexp "^e2wm:ad-override" t)
   (add-hook 'kill-buffer-hook 'e2wm:kill-buffer-hook)
@@ -1138,12 +1119,8 @@ defined by the perspective."
                 (not (null (e2wm:managed-p frame))) frame)
   (cond
    ((e2wm:managed-p frame)
-    (e2wm:aif (previous-frame frame)
-        (e2wm:pst-minor-mode-backup-frame-keymap it))
     (e2wm:pst-minor-mode-enable-frame frame))
    (t
-    (e2wm:aif (previous-frame frame)
-        (e2wm:pst-minor-mode-backup-frame-keymap it))
     (e2wm:pst-minor-mode-disable-frame frame))))
 
 (defadvice handle-switch-frame (around e2wm:ad-frame-override (event))


### PR DESCRIPTION
pst インスタンスに keymap を再構成する情報は既にあるので、backup をとるよりフレーム切り替えの度に再構成してしまえばコードがシンプルになるのでは、と思いました。GUI環境の keymap 切り替えの問題も解決します。
