### PR TITLE
Revert "Protect against display method chaining window"

### DIFF
--- a/e2wm.el
+++ b/e2wm.el
@@ -1324,10 +1324,8 @@ removes the buried buffer from the history list."
       (e2wm:with-advice
        (e2wm:message "#AD-SPECIAL-DISPLAY-FUNC %s" buf)
        (e2wm:history-add buf)
-       (save-selected-window
-         (save-excursion
-           (setq overrided
-                 (e2wm:pst-display-buffer (get-buffer-create buf)))))))
+       (save-excursion
+         (setq overrided (e2wm:pst-display-buffer (get-buffer-create buf))))))
     (if overrided
         (progn 
           ;(set-buffer buf)


### PR DESCRIPTION
Because it is impossible to use, for example, pop-to-buffer
when display-buffer method is wrapped by save-selected-window.
This reverts commit 07450c7192caa37fcd84529f05e03dc96afe7821.

fixes #58
