### PR TITLE
Use "switch to buffer" step from espuds (7 failed scenarios)

### DIFF
--- a/features/e2wm.feature
+++ b/features/e2wm.feature
@@ -43,7 +43,7 @@ Feature: Simple window management
     Given I enabled e2wm
     When I switch to "stwo" perspective
     Then I should be in window "left"
-     And I switch to a buffer "recordable-1"
+     And I switch to buffer "recordable-1"
     When I have a popup buffer "recordable-2"
     Then I should be in window "right"
      And I should be in buffer "recordable-2"
@@ -54,7 +54,7 @@ Feature: Simple window management
     Given I enabled e2wm
     When I switch to "stwo" perspective
      And I switch to window "right"
-     And I switch to a buffer "recordable-1"
+     And I switch to buffer "recordable-1"
     When I have a popup buffer "recordable-2"
     Then I should be in window "left"
      And I should be in buffer "recordable-2"
@@ -65,7 +65,7 @@ Feature: Simple window management
     Given I enabled e2wm
     When I switch to "stwo" perspective
     Then I should be in window "left"
-     And I switch to a buffer "recordable-1"
+     And I switch to buffer "recordable-1"
      And I execute a command that reopens buffer "recordable-2" in other window
     Then I should be in window "right"
      And I should be in buffer "recordable-2"
@@ -75,7 +75,7 @@ Feature: Simple window management
   Scenario: Killing the blank buffer should not cause a problem (#42)
     Given I enabled e2wm
     When I switch to "code" perspective
-     And I switch to a buffer " *e2wm:blank*"
+     And I switch to buffer " *e2wm:blank*"
      And I press "C-x k RET"
      And I switch to buffer "recordable"
      And I press "C-x k RET"

--- a/features/history.feature
+++ b/features/history.feature
@@ -6,9 +6,9 @@ Feature: History management
   Scenario: Open three recordable buffers
     Given I enabled e2wm
     When I switch to "code" perspective
-     And I switch to a buffer "recordable-buffer-a"
-     And I switch to a buffer "recordable-buffer-b"
-     And I switch to a buffer "recordable-buffer-c"
+     And I switch to buffer "recordable-buffer-a"
+     And I switch to buffer "recordable-buffer-b"
+     And I switch to buffer "recordable-buffer-c"
     Then I should have these buffers in history:
       | Pointer | Buffer Name         |
       | ->      | recordable-buffer-c |
@@ -18,12 +18,12 @@ Feature: History management
   Scenario: Ignore unrecordable buffers
     Given I enabled e2wm
     When I switch to "code" perspective
-     And I switch to a buffer "unrecordable-buffer-1"
-     And I switch to a buffer "recordable-buffer-a"
-     And I switch to a buffer "unrecordable-buffer-2"
-     And I switch to a buffer "recordable-buffer-b"
-     And I switch to a buffer "unrecordable-buffer-3"
-     And I switch to a buffer "recordable-buffer-c"
+     And I switch to buffer "unrecordable-buffer-1"
+     And I switch to buffer "recordable-buffer-a"
+     And I switch to buffer "unrecordable-buffer-2"
+     And I switch to buffer "recordable-buffer-b"
+     And I switch to buffer "unrecordable-buffer-3"
+     And I switch to buffer "recordable-buffer-c"
     Then I should have these buffers in history:
       | Pointer | Buffer Name         |
       | ->      | recordable-buffer-c |
@@ -33,9 +33,9 @@ Feature: History management
   Scenario: Go back and forth
     Given I enabled e2wm
     When I switch to "code" perspective
-     And I switch to a buffer "recordable-buffer-a"
-     And I switch to a buffer "recordable-buffer-b"
-     And I switch to a buffer "recordable-buffer-c"
+     And I switch to buffer "recordable-buffer-a"
+     And I switch to buffer "recordable-buffer-b"
+     And I switch to buffer "recordable-buffer-c"
     Then I should have these buffers in history:
       | Pointer | Buffer Name         |
       | ->      | recordable-buffer-c |
@@ -63,9 +63,9 @@ Feature: History management
   Scenario: Open and then kill three recordable buffers
     Given I enabled e2wm
     When I switch to "code" perspective
-     And I switch to a buffer "recordable-buffer-a"
-     And I switch to a buffer "recordable-buffer-b"
-     And I switch to a buffer "recordable-buffer-c"
+     And I switch to buffer "recordable-buffer-a"
+     And I switch to buffer "recordable-buffer-b"
+     And I switch to buffer "recordable-buffer-c"
     Then I should have these buffers in history:
       | Pointer | Buffer Name         |
       | ->      | recordable-buffer-c |

--- a/features/step-definitions/e2wm-steps.el
+++ b/features/step-definitions/e2wm-steps.el
@@ -93,10 +93,6 @@
      (lambda (buffer-name)
        (pop-to-buffer (get-buffer-create buffer-name))))
 
-(And "^I switch to a buffer \"\\(.+\\)\"$"
-     (lambda (buffer-name)
-       (switch-to-buffer (get-buffer-create buffer-name))))
-
 (When "^I display buffer \"\\(.+\\)\"$"
   (lambda (buffer-name)
     (display-buffer (get-buffer-create buffer-name))))
@@ -108,7 +104,7 @@
 (When "^I switch to window \"\\(.+\\)\" and open buffer \"\\(.+\\)\"$"
       (lambda (window-name buffer-name)
         (When "I switch to window \"%s\"" window-name)
-        (And "I switch to a buffer \"%s\"" buffer-name)))
+        (And "I switch to buffer \"%s\"" buffer-name)))
 
 (When "^windows are distorted due to manual rearrangement$"
   "Simulate manual rearrangement of window."


### PR DESCRIPTION
As of rejeep/espuds#11, "I switch to buffer" supports buffer
starts with spaces.

The step defined in espuds uses keyboard macro rather than calling
`switch-to-buffer` function directly and therefore more close to
the real use.  Currently there are 7 failed scenarios.

---

switch-to-buffer を呼ぶ代わりにキーボードマクロで "C-x b BUFFER-NAME" を叩くようにテストを変更した結果、7つのシナリオが通らなくなりました。テストのバグなのか e2wm 自体のバグなのかわかりませんが、interactiveに試しても同様の問題が発生することから、 e2wm 自体にバグがあるんじゃないかと思っています。

すぐに解決出来るか分からないので、 issue 登録の意味も含めて PR しておきます。
