### PR TITLE
Fix: Follow to change function name of magit.el

### DIFF
--- a/e2wm-vcs.el
+++ b/e2wm-vcs.el
@@ -107,7 +107,7 @@
   (e2wm:def-plugin-vcs-with-window
    'magit-get-top-dir
    (lambda (dir topdir)
-     (magit-display-log nil))
+     (magit-log nil))
    (lambda () (e2wm:def-plugin-vcs-na-buffer "Git N/A"))))
 
 (e2wm:plugin-register 'magit-logs


### PR DESCRIPTION
現在の最新のe2wmとmagitで、magit perspectiveに切り替えるとコミットログが表示されませんでした。こちらで調べた結果、magit側で関数名が変更されたのではないかという結論に至り、修正してみました。
