### PR TITLE
fix to up to svn top dir

### DIFF
--- a/e2wm-vcs.el
+++ b/e2wm-vcs.el
@@ -369,7 +369,7 @@
   (let* ((expanded-dir (expand-file-name dir))
          (svndir (member ".svn" (directory-files expanded-dir))))
     (cond
-     ((null svndir) nil)
+     (svndir expanded-dir)
      ((or 
        (string= expanded-dir "/")
        (string= expanded-dir (expand-file-name "~/"))) nil)


### PR DESCRIPTION
`e2wm:def-plugin-svn-top-dir`は、
".svn"があるフォルダを探して親ディレクトリを辿っていく仕様だと思いますが、
現状では、カレントに存在しない時点で`nil`を返してしまっているので、
ワーキングコピーの子階層で`e2wm:dp-svn`すると、"Subversion N/A"となってしまいます。
