### PR TITLE
start perspective of vcs from any buffer

### DIFF
--- a/e2wm-vcs.el
+++ b/e2wm-vcs.el
@@ -58,15 +58,19 @@
 
 
 (defun e2wm:def-plugin-vcs-with-window (topdir-func body-func na-buffer-func)
-  (let* ((buf (e2wm:history-get-main-buffer))
+  (let* ((buf (or e2wm:prev-selected-buffer
+                  (wlf:get-buffer (e2wm:pst-get-wm)
+                                  (e2wm:$pst-main (e2wm:pst-get-instance)))
+                  (current-buffer)))
          (file (buffer-file-name buf))
-         (dir (or (and file (file-name-directory file)) default-directory))
+         (dir (or (and file (file-name-directory file))
+                  (with-current-buffer buf default-directory)))
          (topdir (and dir (funcall topdir-func dir))))
     (e2wm:with-advice
      (cond
       (topdir
        (with-selected-window (wlf:get-window wm (wlf:window-name winfo))
-         (with-current-buffer buf 
+         (with-current-buffer buf
            (funcall body-func dir topdir))
          (wlf:set-buffer wm (wlf:window-name winfo)
                          (window-buffer (selected-window)))))


### PR DESCRIPTION
現状、`e2wm:dp-magit`や`e2wm:dp-svn`は、管理下にあるファイルを開いた状態からでないと、
"... N/A"となってしまうかと思いますが、私はシェルやDiredのバッファからでも開始したいと思いました。
恐らく他のユーザも同様に感じるのではないかと思ったので、prしました。
自分の使い方では、この修正で期待通りの動作ができているように感じていますが、
何かまずい点があれば、教えて頂けると幸いです。
