### PR TITLE
fix to return from array perspective when previous pst not exist

### DIFF
--- a/e2wm.el
+++ b/e2wm.el
@@ -3795,7 +3795,7 @@ Do not select the buffer."
   (interactive)
   (e2wm:not-minibuffer
    (or (e2wm:pst-change-prev)
-       (let (buf (current-buffer))
+       (let ((buf (current-buffer)))
          (e2wm:stop-management)
          (switch-to-buffer buf)))))
 (defun e2wm:dp-array-toggle-more-buffers-command ()


### PR DESCRIPTION
`e2wm:start-management`していない状態で、`e2wm:dp-array`すると、
`C-m`でも`C-g`でも、画面構成が戻らなくなってしまいます。

`e2wm:start-management`無しで、`e2wm:dp-array`したいのです。
#70 と合わせて、それができるのではないかと思うのですが、どうでしょうか？
