### PR TITLE
prefer magit-status-internal to magit-status

### DIFF
--- a/e2wm-vcs.el
+++ b/e2wm-vcs.el
@@ -122,7 +122,9 @@
   (e2wm:def-plugin-vcs-with-window
    'magit-get-top-dir
    (lambda (dir topdir)
-     (magit-status (file-name-as-directory dir)))
+     (loop for f in '(magit-status-internal magit-status)
+           if (fboundp f)
+           return (funcall f (file-name-as-directory dir))))
    (lambda () (e2wm:history-get-main-buffer))))
 
 (e2wm:plugin-register 'magit-status


### PR DESCRIPTION
最近 magit を更新したら、 magit-status の挙動が変わっていて、
リポジトリのルートでない階層で実行すると、リポジトリを作るか聞かれるようになってしまっていて、
そのかわりに、 magit-status-internal という関数が定義されたので、そちらを優先的に使うようにしました。