### PR TITLE
try to call functions to show magit branch buffer

### DIFF
--- a/e2wm-vcs.el
+++ b/e2wm-vcs.el
@@ -98,9 +98,10 @@
 (defun e2wm:def-plugin-magit-branches (frame wm winfo)
   (e2wm:def-plugin-vcs-with-window
    'magit-get-top-dir
-   (if (fboundp 'magit-branch-manager)
-       (lambda (dir topdir) (magit-branch-manager))
-     (lambda (dir topdir) (magit-show-branches)))
+   (lambda (dir topdir)
+     (dolist (f '(magit-show-branches magit-branch-manager magit-show-refs-head))
+       (when (fboundp f)
+         (funcall f))))
    (lambda () (e2wm:def-plugin-vcs-na-buffer "Git N/A"))))
 
 (e2wm:plugin-register 'magit-branches


### PR DESCRIPTION
最近 magit を更新したら、 magit-branch-master がなくなっていて、代わりに magit-show-refs-head というのが定義されたようです。

今は、 magit-branch-master を magit-show-branches より優先してますが、これはこの順序じゃないとダメですか？
一応、関数を古いものから順に試した方が確実かなと思って、このようにしてみましたが、どうでしょうか？
