### PR TITLE
limit magit log buffer size for performance

### DIFF
--- a/e2wm-vcs.el
+++ b/e2wm-vcs.el
@@ -111,7 +111,8 @@
   (e2wm:def-plugin-vcs-with-window
    'magit-get-top-dir
    (lambda (dir topdir)
-     (magit-log nil))
+     (magit-log nil (or (ignore-errors magit-log-section-arguments)
+                        '("-n256" "--decorate"))))
    (lambda () (e2wm:def-plugin-vcs-na-buffer "Git N/A"))))
 
 (e2wm:plugin-register 'magit-logs


### PR DESCRIPTION
最近 magit を更新したら、リビジョンを大きいプロジェクトでフリーズするようになってしまって、
ログバッファのサイズを制限することで、解消できました。

magit-log は大分前から引数は変わっていないように見えたので、オプションを指定するようにしました。
magit-log-section-arguments は 2016/01 頃追加されたようです。
defcustomなので、ignore-errorsで雑に存在有無を見るので良いのではないかと思いました。